### PR TITLE
Task/Automatic-Selection, rewrote the SelectionComponentRepainter class

### DIFF
--- a/JHotDraw/src/main/java/org/jhotdraw/draw/action/AbstractComponentRepainter.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/action/AbstractComponentRepainter.java
@@ -1,0 +1,35 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jhotdraw.draw.action;
+
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.draw.FigureEvent;
+
+/**
+ *
+ * @author svane
+ */
+public interface AbstractComponentRepainter extends PropertyChangeListener {
+    
+    // Methods for PropertyChangeListener
+    public void propertyChange(PropertyChangeEvent evt);
+    
+   // Methods implements in both SelectionComponentPainter &
+   // DrawingComponentRepainter
+    public void attributeChanged(FigureEvent evt);
+    public void dispose();
+    
+    // Methods for Listeners
+    public void addListeners(DrawingView view);
+    public void removeListeners(DrawingView view);
+    
+    //Methods for different views
+    public void activeViewPropertyChangedHandler(PropertyChangeEvent evt);
+    public void drawingPropertyChangedHandler(PropertyChangeEvent evt);
+}

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/action/SelectionComponentRepainter.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/action/SelectionComponentRepainter.java
@@ -13,10 +13,8 @@
  */
 package org.jhotdraw.draw.action;
 
-import dk.sdu.mmmi.featuretracer.lib.FeatureEntryPoint;
 import java.beans.*;
 import javax.swing.*;
-import org.jhotdraw.app.JHotDrawFeatures;
 import org.jhotdraw.draw.*;
 
 /**
@@ -29,12 +27,12 @@ import org.jhotdraw.draw.*;
 
 // The class is similar to the DrawingComponentPainter - Duplicate code
 public class SelectionComponentRepainter extends FigureAdapter
-        implements PropertyChangeListener, FigureSelectionListener {
+        implements FigureSelectionListener, AbstractComponentRepainter {
 
     private DrawingEditor editor;
     private JComponent component;
-
-    // Constructor rewritten to use addListeners
+    
+    // Constructor uses addListeners to reduce the code
     public SelectionComponentRepainter(DrawingEditor editor, JComponent component) {
         this.editor = editor;
         this.component = component;
@@ -56,10 +54,12 @@ public class SelectionComponentRepainter extends FigureAdapter
      * Rewrote the propertyChange() to use the 
      * activeViewPropertyChangedHandler() or the drawingPropertyChangedHandler()
      * depending on if the propertyName hits the Active View or the DrawingView
-     * @param evt the propertyName to determine if the method executes the logic
+     * @param evt A PropertyChangeEvent object describing the event source and 
+     * the property that has changed to determine if the method executes the logic
      * for activeViewPropertyChangedHandler() or 
      * drawingPropertyChangedHandler()
      */
+    @Override
     public void propertyChange(PropertyChangeEvent evt) {
         String name = evt.getPropertyName();
         
@@ -72,11 +72,13 @@ public class SelectionComponentRepainter extends FigureAdapter
         }
     }
 
+    @Override
     public void selectionChanged(FigureSelectionEvent evt) {
         component.repaint();
     }
 
     // Used removeListeners to reduce the code 
+    @Override
     public void dispose() {
         if (editor != null) {
             if (editor.getActiveView() != null) {
@@ -91,9 +93,10 @@ public class SelectionComponentRepainter extends FigureAdapter
     
     /**
      * Adds the listeners
-     * @param view the DrawingView Object
+     * @param view paints a Drawing on a JComponent
      */
-    private void addListeners(DrawingView view) {
+    @Override
+    public void addListeners(DrawingView view) {
         view.addPropertyChangeListener(this);
         view.addFigureSelectionListener(this);
                 
@@ -103,10 +106,11 @@ public class SelectionComponentRepainter extends FigureAdapter
     }
     
     /**
-     * removes the listeners
-     * @param view the DrawingView Object
+     * Removes the listeners
+     * @param view paints a Drawing on a JComponent
      */
-    private void removeListeners(DrawingView view) {
+    @Override
+    public void removeListeners(DrawingView view) {
         view.removePropertyChangeListener(this);
         view.removeFigureSelectionListener(this);
         
@@ -121,7 +125,8 @@ public class SelectionComponentRepainter extends FigureAdapter
      * for the Active View 
      * @param evt the values for the DrawingView Object
      */
-    private void activeViewPropertyChangedHandler(PropertyChangeEvent evt) {
+    @Override
+    public void activeViewPropertyChangedHandler(PropertyChangeEvent evt) {
         DrawingView view = (DrawingView) evt.getOldValue();
         
         if (view != null) {
@@ -143,7 +148,8 @@ public class SelectionComponentRepainter extends FigureAdapter
      * for the Drawing
      * @param evt the values for the DrawingView Object
      */
-    private void drawingPropertyChangedHandler(PropertyChangeEvent evt) {
+    @Override
+    public void drawingPropertyChangedHandler(PropertyChangeEvent evt) {
         Drawing drawing = (Drawing) evt.getOldValue();
         
         if (drawing != null) {

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/action/SelectionComponentRepainter.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/action/SelectionComponentRepainter.java
@@ -34,18 +34,14 @@ public class SelectionComponentRepainter extends FigureAdapter
     private DrawingEditor editor;
     private JComponent component;
 
-    // Write method to check if the editor is null
+    // Constructor rewritten to use addListeners
     public SelectionComponentRepainter(DrawingEditor editor, JComponent component) {
         this.editor = editor;
         this.component = component;
         if (editor != null) {
             if (editor.getActiveView() != null) {
                 DrawingView view = editor.getActiveView();
-                view.addPropertyChangeListener(this);
-                view.addFigureSelectionListener(this);
-                if (view.getDrawing() != null) {
-                    view.getDrawing().addFigureListener(this);
-                }
+                this.addListeners(view);
             }
             editor.addPropertyChangeListener(this);
         }
@@ -56,37 +52,21 @@ public class SelectionComponentRepainter extends FigureAdapter
         component.repaint();
     }
 
-    // Method will be changed due to long method
+    /**
+     * Rewrote the propertyChange() to use the 
+     * activeViewPropertyChangedHandler() or the drawingPropertyChangedHandler()
+     * depending on if the propertyName hits the Active View or the DrawingView
+     * @param evt the propertyName to determine if the method executes the logic
+     * for activeViewPropertyChangedHandler() or 
+     * drawingPropertyChangedHandler()
+     */
     public void propertyChange(PropertyChangeEvent evt) {
         String name = evt.getPropertyName();
+        
         if (name == DrawingEditor.ACTIVE_VIEW_PROPERTY) {
-            DrawingView view = (DrawingView) evt.getOldValue();
-            if (view != null) {
-                view.removePropertyChangeListener(this);
-                view.removeFigureSelectionListener(this);
-                if (view.getDrawing() != null) {
-                    view.getDrawing().removeFigureListener(this);
-                }
-            }
-            view = (DrawingView) evt.getNewValue();
-            if (view != null) {
-                view.addPropertyChangeListener(this);
-                view.addFigureSelectionListener(this);
-                if (view.getDrawing() != null) {
-                    view.getDrawing().addFigureListener(this);
-                }
-            }
-            component.repaint();
+            this.activeViewPropertyChangedHandler(evt);
         } else if (name == DrawingView.DRAWING_PROPERTY) {
-            Drawing drawing = (Drawing) evt.getOldValue();
-            if (drawing != null) {
-                drawing.removeFigureListener(this);
-            }
-            drawing = (Drawing) evt.getNewValue();
-            if (drawing != null) {
-                drawing.addFigureListener(this);
-            }
-            component.repaint();
+            this.drawingPropertyChangedHandler(evt);
         } else {
             component.repaint();
         }
@@ -96,21 +76,87 @@ public class SelectionComponentRepainter extends FigureAdapter
         component.repaint();
     }
 
-    // Write method to remove Listeners
+    // Used removeListeners to reduce the code 
     public void dispose() {
         if (editor != null) {
             if (editor.getActiveView() != null) {
                 DrawingView view = editor.getActiveView();
-                view.removePropertyChangeListener(this);
-                view.removeFigureSelectionListener(this);
-                if (view.getDrawing() != null) {
-                    view.getDrawing().removeFigureListener(this);
-                }
+                this.removeListeners(view);
             }
             editor.removePropertyChangeListener(this);
             editor = null;
         }
         component = null;
+    }
+    
+    /**
+     * Adds the listeners
+     * @param view the DrawingView Object
+     */
+    private void addListeners(DrawingView view) {
+        view.addPropertyChangeListener(this);
+        view.addFigureSelectionListener(this);
+                
+        if (view.getDrawing() != null) {
+            view.getDrawing().addFigureListener(this);
+        }
+    }
+    
+    /**
+     * removes the listeners
+     * @param view the DrawingView Object
+     */
+    private void removeListeners(DrawingView view) {
+        view.removePropertyChangeListener(this);
+        view.removeFigureSelectionListener(this);
+        
+        if (view.getDrawing() != null) {
+            view.getDrawing().removeFigureListener(this);
+        }
+    }
+    
+    /**
+     * Updates the old values with the new values by removing the old
+     * listeners and adding the new listeners when the values are changed
+     * for the Active View 
+     * @param evt the values for the DrawingView Object
+     */
+    private void activeViewPropertyChangedHandler(PropertyChangeEvent evt) {
+        DrawingView view = (DrawingView) evt.getOldValue();
+        
+        if (view != null) {
+            this.removeListeners(view);
+        }
+        
+        view = (DrawingView) evt.getNewValue();
+        
+        if (view != null) {
+           this.addListeners(view);
+        }
+        
+        component.repaint();
+    }
+    
+    /**
+     * Updates the old values with the new values by removing the old
+     * listeners and adding the new listeners when the values are changed
+     * for the Drawing
+     * @param evt the values for the DrawingView Object
+     */
+    private void drawingPropertyChangedHandler(PropertyChangeEvent evt) {
+        Drawing drawing = (Drawing) evt.getOldValue();
+        
+        if (drawing != null) {
+            drawing.removeFigureListener(this);
+        }
+        
+        drawing = (Drawing) evt.getNewValue();
+        
+        if (drawing != null) {
+            drawing.addFigureListener(this);
+        }
+        
+        component.repaint();
     }
 }
 


### PR DESCRIPTION
due to long methods as the propertyChange method to use to methods to
to increase readability and understanding and added methods to 
add or remove listeners due to duplicate code

## Feature change request
- [x] Automatic Selection
- [ ] Align Palette
- [ ] Arrange
- [ ] Basic Editing
- [ ] Line Tool
- [ ] Font palette
- [ ] Rectangle Tool
- [ ] Tool Palette
- [ ] Text Tool
- [ ] Undo / Redo

## Description
Rewrote the SelectionComponentRepainter class
due to long methods as the propertyChange method to use to methods to
to increase readability and understanding and added methods to 
add or remove listeners due to duplicate code

## Automatic Tests
- [ ] Automatic test added / updated
- [x] Automatic tests not required
